### PR TITLE
Feature/wait times as parameters

### DIFF
--- a/include/tsif/timeline.h
+++ b/include/tsif/timeline.h
@@ -144,10 +144,10 @@ class Timeline{
     return out.str();
   }
 
-  void SetMaxWaitTime(double max_wait_time){
+  void SetMaxWaitTime(const double& max_wait_time){
     max_wait_time_ = fromSec(max_wait_time);
   }
-  void SetMinWaitTime(double min_wait_time){
+  void SetMinWaitTime(const double& min_wait_time){
     min_wait_time_ = fromSec(min_wait_time);
   }
 
@@ -196,10 +196,10 @@ class Timeline<MeasEmpty>{
     return out.str();
   }
 
-  void SetMaxWaitTime(double max_wait_time){
+  void SetMaxWaitTime(const double& max_wait_time){
     max_wait_time_ = fromSec(max_wait_time);
   }
-  void SetMinWaitTime(double min_wait_time){
+  void SetMinWaitTime(const double& min_wait_time){
     min_wait_time_ = fromSec(min_wait_time);
   }
 

--- a/include/tsif/timeline.h
+++ b/include/tsif/timeline.h
@@ -143,6 +143,15 @@ class Timeline{
     };
     return out.str();
   }
+
+  void SetMaxWaitTime(double max_wait_time){
+    max_wait_time_ = fromSec(max_wait_time);
+  }
+  void SetMinWaitTime(double min_wait_time){
+    min_wait_time_ = fromSec(min_wait_time);
+  }
+
+ protected:
   Duration max_wait_time_;
   Duration min_wait_time_;
 };
@@ -186,6 +195,15 @@ class Timeline<MeasEmpty>{
     for(int i=0;i<c;i++) out << "-";
     return out.str();
   }
+
+  void SetMaxWaitTime(double max_wait_time){
+    max_wait_time_ = fromSec(max_wait_time);
+  }
+  void SetMinWaitTime(double min_wait_time){
+    min_wait_time_ = fromSec(min_wait_time);
+  }
+
+ protected:
   Duration max_wait_time_;
   Duration min_wait_time_;
 };

--- a/include/tsif/timeline.h
+++ b/include/tsif/timeline.h
@@ -143,8 +143,8 @@ class Timeline{
     };
     return out.str();
   }
-  const Duration max_wait_time_;
-  const Duration min_wait_time_;
+  Duration max_wait_time_;
+  Duration min_wait_time_;
 };
 
 template<>
@@ -186,8 +186,8 @@ class Timeline<MeasEmpty>{
     for(int i=0;i<c;i++) out << "-";
     return out.str();
   }
-  const Duration max_wait_time_;
-  const Duration min_wait_time_;
+  Duration max_wait_time_;
+  Duration min_wait_time_;
 };
 
 } // namespace tsif


### PR DESCRIPTION
* max/min_wait_time members of Timeline are protected and get setters instead of being const as a minimal solution to set the wait times as parameters in filters