### PR TITLE
added tsif::Filter::Clear() to completely clear the filter timelines

### DIFF
--- a/include/tsif/filter.h
+++ b/include/tsif/filter.h
@@ -117,6 +117,14 @@ class Filter{
   template<int C = 0, typename std::enable_if<(C >= kN)>::type* = nullptr>
   void Clean(TimePoint time){}
 
+  template<int C = 0, typename std::enable_if<(C < kN)>::type* = nullptr>
+  void Clear(){
+    std::get<C>(timelines_).Clear();
+    Clear<C+1>();
+  }
+  template<int C = 0, typename std::enable_if<(C >= kN)>::type* = nullptr>
+  void Clear(){}
+
   virtual void Init(TimePoint t){
     if(GetMinMaxTime() != TimePoint::min()){
       TSIF_LOG("Initializing state at t = " << Print(t));

--- a/include/tsif/timeline.h
+++ b/include/tsif/timeline.h
@@ -35,6 +35,9 @@ class Timeline{
       RemoveFirst();
     }
   }
+  void Clear(){
+    mm_.clear();
+  }
   int CountSmallerOrEqual(TimePoint t){
     int count = 0;
     auto it = mm_.upper_bound(t);
@@ -172,6 +175,8 @@ class Timeline<MeasEmpty>{
     return std::make_shared<MeasEmpty>();
   }
   void Clean(TimePoint t){
+  }
+  void Clear(){
   }
   TimePoint GetLastTime() const{
     return TimePoint::max();


### PR DESCRIPTION
* handy to cleanly reset the filter (to avoid undesired effects of measurements added before the reset)