### PR TITLE
feature/vio residual mods

### DIFF
--- a/include/tsif/residuals/bearing_findif.h
+++ b/include/tsif/residuals/bearing_findif.h
@@ -26,7 +26,7 @@ class BearingFindif: public BearingFindifBase<OUT_BEA,STA_BEA,STA_DIS,STA_VEL,ST
   typedef typename Base::Output Output;
   typedef typename Base::Previous Previous;
   typedef typename Base::Current Current;
-  BearingFindif(): Base(true,true,true), vep_not_param_(STA_VEP>=0), vea_not_param_(STA_VEA>=0){}
+  BearingFindif(): Base(true,true,true), vep_not_fixed_(STA_VEP>=0), vea_not_fixed_(STA_VEA>=0){}
   int EvalRes(typename Output::Ref out, const typename Previous::CRef pre, const typename Current::CRef cur){
     UnitVector n_predicted;
     const Mat3 C_VI = pre.template Get<STA_VEA>().toRotationMatrix();
@@ -95,16 +95,16 @@ class BearingFindif: public BearingFindifBase<OUT_BEA,STA_BEA,STA_DIS,STA_VEL,ST
       J.block<2,1>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_DIS)+i) = -dt_*Jsub_1*Jsub_2b*beaN.transpose()*beaVec.cross(vel);
       J.block<2,2>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_BEA)+2*i) = -dt_*Jsub_1*Jsub_2b*(-invDis*beaN.transpose()*SSM(vel)*beaM
           +beaN.transpose()*SSM(ror + invDis * beaVec.cross(vel))*beaN) + Jsub_1*Jsub_2a;
-      if (vep_not_param_) J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
-      if (vea_not_param_) J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEA)) = - J_ror*SSM(ror) - J_vel*SSM(vel);
+      if (vep_not_fixed_) J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
+      if (vea_not_fixed_) J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEA)) = - J_ror*SSM(ror) - J_vel*SSM(vel);
     }
   }
   double GetWeight(){
     return w_/sqrt(dt_);
   }
  protected:
-  const bool vep_not_param_;
-  const bool vea_not_param_;
+  const bool vep_not_fixed_;
+  const bool vea_not_fixed_;
 };
 
 } // namespace tsif

--- a/include/tsif/residuals/bearing_findif.h
+++ b/include/tsif/residuals/bearing_findif.h
@@ -48,6 +48,7 @@ class BearingFindif: public BearingFindifBase<OUT_BEA,STA_BEA,STA_DIS,STA_VEL,ST
     return 0;
   }
   int JacCur(MatRefX J, const typename Previous::CRef pre, const typename Current::CRef cur){
+    J.setZero();
     UnitVector n_predicted;
     const Mat3 C_VI = pre.template Get<STA_VEA>().toRotationMatrix();
     const Vec3 ror = C_VI*pre.template Get<STA_ROR>();
@@ -66,6 +67,7 @@ class BearingFindif: public BearingFindifBase<OUT_BEA,STA_BEA,STA_DIS,STA_VEL,ST
     return 0;
   }
   void JacPreCustom(MatRefX J, const typename Previous::CRef pre, const typename Current::CRef cur, bool predictionOnly){
+    J.setZero();
     UnitVector n_predicted;
     const Mat3 C_VI = pre.template Get<STA_VEA>().toRotationMatrix();
     const Vec3 ror = C_VI*pre.template Get<STA_ROR>();
@@ -93,8 +95,8 @@ class BearingFindif: public BearingFindifBase<OUT_BEA,STA_BEA,STA_DIS,STA_VEL,ST
       J.block<2,1>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_DIS)+i) = -dt_*Jsub_1*Jsub_2b*beaN.transpose()*beaVec.cross(vel);
       J.block<2,2>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_BEA)+2*i) = -dt_*Jsub_1*Jsub_2b*(-invDis*beaN.transpose()*SSM(vel)*beaM
           +beaN.transpose()*SSM(ror + invDis * beaVec.cross(vel))*beaN) + Jsub_1*Jsub_2a;
-      J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
-      J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEA)) = - J_ror*SSM(ror) - J_vel*SSM(vel);
+      if (STA_VEP>=0) J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
+      if (STA_VEA>=0) J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEA)) = - J_ror*SSM(ror) - J_vel*SSM(vel);
     }
   }
   double GetWeight(){

--- a/include/tsif/residuals/bearing_findif.h
+++ b/include/tsif/residuals/bearing_findif.h
@@ -26,7 +26,7 @@ class BearingFindif: public BearingFindifBase<OUT_BEA,STA_BEA,STA_DIS,STA_VEL,ST
   typedef typename Base::Output Output;
   typedef typename Base::Previous Previous;
   typedef typename Base::Current Current;
-  BearingFindif(): Base(true,true,true){}
+  BearingFindif(): Base(true,true,true), vep_not_param_(STA_VEP>=0), vea_not_param_(STA_VEA>=0){}
   int EvalRes(typename Output::Ref out, const typename Previous::CRef pre, const typename Current::CRef cur){
     UnitVector n_predicted;
     const Mat3 C_VI = pre.template Get<STA_VEA>().toRotationMatrix();
@@ -95,13 +95,16 @@ class BearingFindif: public BearingFindifBase<OUT_BEA,STA_BEA,STA_DIS,STA_VEL,ST
       J.block<2,1>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_DIS)+i) = -dt_*Jsub_1*Jsub_2b*beaN.transpose()*beaVec.cross(vel);
       J.block<2,2>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_BEA)+2*i) = -dt_*Jsub_1*Jsub_2b*(-invDis*beaN.transpose()*SSM(vel)*beaM
           +beaN.transpose()*SSM(ror + invDis * beaVec.cross(vel))*beaN) + Jsub_1*Jsub_2a;
-      if (STA_VEP>=0) J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
-      if (STA_VEA>=0) J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEA)) = - J_ror*SSM(ror) - J_vel*SSM(vel);
+      if (vep_not_param_) J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
+      if (vea_not_param_) J.block<2,3>(Output::Start(OUT_BEA)+2*i,pre.Start(STA_VEA)) = - J_ror*SSM(ror) - J_vel*SSM(vel);
     }
   }
   double GetWeight(){
     return w_/sqrt(dt_);
   }
+ protected:
+  const bool vep_not_param_;
+  const bool vea_not_param_;
 };
 
 } // namespace tsif

--- a/include/tsif/residuals/distance_findif.h
+++ b/include/tsif/residuals/distance_findif.h
@@ -26,7 +26,7 @@ class DistanceFindif: public DistanceFindifBase<OUT_DIS,STA_BEA,STA_DIS,STA_VEL,
   typedef typename Base::Output Output;
   typedef typename Base::Previous Previous;
   typedef typename Base::Current Current;
-  DistanceFindif(): Base(true,true,true){}
+  DistanceFindif(): Base(true,true,true), vep_not_param_(STA_VEP>=0), vea_not_param_(STA_VEA>=0){}
   int EvalRes(typename Output::Ref out, const typename Previous::CRef pre, const typename Current::CRef cur){
     const Mat3 C_VI = pre.template Get<STA_VEA>().toRotationMatrix();
     const Vec3 vel = C_VI*(pre.template Get<STA_VEL>() + pre.template Get<STA_ROR>().cross(pre.template Get<STA_VEP>()));
@@ -51,8 +51,8 @@ class DistanceFindif: public DistanceFindifBase<OUT_DIS,STA_BEA,STA_DIS,STA_VEL,
       J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_ROR)) = -J_vel*C_VI*SSM(pre.template Get<STA_VEP>());
       J.block<1,1>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_DIS)+1*i) = Mat<1>::Identity()+dt_*2*beaVec.transpose()*vel*invDis;
       J.block<1,2>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_BEA)+2*i) = dt_*vel.transpose()*invDis*invDis*bea.GetM();
-      if (STA_VEP>=0) J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
-      if (STA_VEA>=0) J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEA)) = - J_vel*SSM(vel);
+      if (vep_not_param_) J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
+      if (vea_not_param_) J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEA)) = - J_vel*SSM(vel);
     }
     return 0;
   }
@@ -66,6 +66,9 @@ class DistanceFindif: public DistanceFindifBase<OUT_DIS,STA_BEA,STA_DIS,STA_VEL,
   double GetWeight(){
     return w_/sqrt(dt_);
   }
+ protected:
+  const bool vep_not_param_;
+  const bool vea_not_param_;
 };
 
 } // namespace tsif

--- a/include/tsif/residuals/distance_findif.h
+++ b/include/tsif/residuals/distance_findif.h
@@ -39,6 +39,7 @@ class DistanceFindif: public DistanceFindifBase<OUT_DIS,STA_BEA,STA_DIS,STA_VEL,
     return 0;
   }
   int JacPre(MatRefX J, const typename Previous::CRef pre, const typename Current::CRef cur){
+    J.setZero();
     const Mat3 C_VI = pre.template Get<STA_VEA>().toRotationMatrix();
     const Vec3 vel = C_VI*(pre.template Get<STA_VEL>() + pre.template Get<STA_ROR>().cross(pre.template Get<STA_VEP>()));
     for(int i=0;i<N;i++){
@@ -50,12 +51,13 @@ class DistanceFindif: public DistanceFindifBase<OUT_DIS,STA_BEA,STA_DIS,STA_VEL,
       J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_ROR)) = -J_vel*C_VI*SSM(pre.template Get<STA_VEP>());
       J.block<1,1>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_DIS)+1*i) = Mat<1>::Identity()+dt_*2*beaVec.transpose()*vel*invDis;
       J.block<1,2>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_BEA)+2*i) = dt_*vel.transpose()*invDis*invDis*bea.GetM();
-      J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
-      J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEA)) = - J_vel*SSM(vel);
+      if (STA_VEP>=0) J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
+      if (STA_VEA>=0) J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEA)) = - J_vel*SSM(vel);
     }
     return 0;
   }
   int JacCur(MatRefX J, const typename Previous::CRef pre, const typename Current::CRef cur){
+    J.setZero();
     for(int i=0;i<N;i++){
       J.block<1,1>(Output::Start(OUT_DIS)+1*i,cur.Start(STA_DIS)+1*i) = -Mat<1>::Identity();
     }

--- a/include/tsif/residuals/distance_findif.h
+++ b/include/tsif/residuals/distance_findif.h
@@ -26,7 +26,7 @@ class DistanceFindif: public DistanceFindifBase<OUT_DIS,STA_BEA,STA_DIS,STA_VEL,
   typedef typename Base::Output Output;
   typedef typename Base::Previous Previous;
   typedef typename Base::Current Current;
-  DistanceFindif(): Base(true,true,true), vep_not_param_(STA_VEP>=0), vea_not_param_(STA_VEA>=0){}
+  DistanceFindif(): Base(true,true,true), vep_not_fixed_(STA_VEP>=0), vea_not_fixed_(STA_VEA>=0){}
   int EvalRes(typename Output::Ref out, const typename Previous::CRef pre, const typename Current::CRef cur){
     const Mat3 C_VI = pre.template Get<STA_VEA>().toRotationMatrix();
     const Vec3 vel = C_VI*(pre.template Get<STA_VEL>() + pre.template Get<STA_ROR>().cross(pre.template Get<STA_VEP>()));
@@ -51,8 +51,8 @@ class DistanceFindif: public DistanceFindifBase<OUT_DIS,STA_BEA,STA_DIS,STA_VEL,
       J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_ROR)) = -J_vel*C_VI*SSM(pre.template Get<STA_VEP>());
       J.block<1,1>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_DIS)+1*i) = Mat<1>::Identity()+dt_*2*beaVec.transpose()*vel*invDis;
       J.block<1,2>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_BEA)+2*i) = dt_*vel.transpose()*invDis*invDis*bea.GetM();
-      if (vep_not_param_) J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
-      if (vea_not_param_) J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEA)) = - J_vel*SSM(vel);
+      if (vep_not_fixed_) J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEP)) = J_vel*C_VI*SSM(pre.template Get<STA_ROR>());
+      if (vea_not_fixed_) J.block<1,3>(Output::Start(OUT_DIS)+1*i,pre.Start(STA_VEA)) = - J_vel*SSM(vel);
     }
     return 0;
   }
@@ -67,8 +67,8 @@ class DistanceFindif: public DistanceFindifBase<OUT_DIS,STA_BEA,STA_DIS,STA_VEL,
     return w_/sqrt(dt_);
   }
  protected:
-  const bool vep_not_param_;
-  const bool vea_not_param_;
+  const bool vep_not_fixed_;
+  const bool vea_not_fixed_;
 };
 
 } // namespace tsif


### PR DESCRIPTION
Makes the jacobian methods of the image feature findif residuals safe wrt the constness of the cam offset state: Checks the sign of the corresponding indices and only sets the relevant jacobian blocks if the offset is really a state, i.e. has a positive index.
The eigen block operations are not compatible with negative-index states and the SetJac* functions of tsif - which would check for the state index sign - do not cover the case of an array state.
