### PR TITLE
feature/loca filter rework post tpl se

### DIFF
--- a/include/tsif/filter.h
+++ b/include/tsif/filter.h
@@ -265,7 +265,8 @@ class Filter{
       std::get<C>(residuals_).JacPre(JacPre_.block<Output::Dim(),State::Dim()>(start,0),state_,curLinState_);
       std::get<C>(residuals_).JacCur(JacCur_.block<Output::Dim(),State::Dim()>(start,0),state_,curLinState_);
       std::get<C>(residuals_).AddNoise(ySub, JacPre_.block<Output::Dim(),State::Dim()>(start,0),
-                                       JacCur_.block<Output::Dim(),State::Dim()>(start,0));
+                                       JacCur_.block<Output::Dim(),State::Dim()>(start,0),
+                                       state_,curLinState_);
       ySub.GetVec(y_.block<Output::Dim(),1>(start, 0));
     }
     ConstructProblem<C+1>(start+Output::Dim()*std::get<C>(residuals_).isActive_);

--- a/include/tsif/residual.h
+++ b/include/tsif/residual.h
@@ -97,7 +97,7 @@ class Residual: public Model<Residual<Out,Pre,Cur,Meas>,Out,Pre,Cur>{
       assert(false);
     }
   }
-  virtual void AddNoise(typename Out::Ref out, MatRefX J_pre, MatRefX J_cur){
+  virtual void AddNoise(typename Out::Ref out, MatRefX J_pre, MatRefX J_cur, const typename Previous::CRef pre, const typename Current::CRef cur){
     AddWeight(GetWeight(),out,J_pre,J_cur);
   }
   void AddWeight(double w, typename Out::Ref out, MatRefX J_pre, MatRefX J_cur){

--- a/include/tsif/residuals/image_update.h
+++ b/include/tsif/residuals/image_update.h
@@ -50,7 +50,7 @@ class ImageUpdate: public ImageUpdateBase<OUT_RES,STA_BEA,N,MEAS>{ // TODO: rena
     }
     return 0;
   }
-  virtual void AddNoise(typename Output::Ref out, MatRefX J_pre, MatRefX J_cur){
+  virtual void AddNoise(typename Output::Ref out, MatRefX J_pre, MatRefX J_cur, const typename Previous::CRef pre, const typename Current::CRef cur){
     for(int i=0;i<N;i++){
       double w = GetWeight();
       const double norm = out.template Get<OUT_RES>()[i].norm();


### PR DESCRIPTION
This implements: 

* a rework of the localization filter within the TSIF state estimator such that the mapToOdom and baseToMap trafos are only updated when new ICP poses are received
* minor improvements in loca filter resetting and initializing
* a fix for state estimator thread safety after a bug was discovered which leads to sporadic segfaults when reset service calls are spammed 

Passing the previous and current state to the AddNoise function made implementing residuals composed of other residuals more convenient (e.g. a pose update from an attitude update plus a position update). On top of that this would allow some more involved weighting schemes in the future.

List of repos with associated PRs:

* anymal
* any_common
* anymal_b
* anymal_bear
* anymal_state_estimator
* two_state_information_filter

The changes were tested successfully on Bany and Bear.