### PR TITLE
Feature/rezero mods

### DIFF
--- a/include/tsif/residuals/accelerometer_prediction.h
+++ b/include/tsif/residuals/accelerometer_prediction.h
@@ -43,14 +43,14 @@ class AccelerometerPrediction: public AccelerometerPredictionBase<OUT_VEL,STA_VE
     return 0;
   }
   int JacPre(MatRefX J, const typename Previous::CRef pre, const typename Current::CRef cur){
-    J.block<3,3>(Output::Start(OUT_VEL),pre.Start(STA_VEL)) = - (Mat3::Identity() - SSM(dt_*pre.template Get<STA_ROR>()));
-    J.block<3,3>(Output::Start(OUT_VEL),pre.Start(STA_ATT)) = -pre.template Get<STA_ATT>().inverse().toRotationMatrix()*SSM(g_*dt_);
-    J.block<3,3>(Output::Start(OUT_VEL),pre.Start(STA_ROR)) = - SSM(dt_*pre.template Get<STA_VEL>());
-    J.block<3,3>(Output::Start(OUT_VEL),pre.Start(STA_ACB)) = dt_*Mat3::Identity();
+    this->template SetJacPre<OUT_VEL, STA_VEL>(J, pre, -(Mat3::Identity() - SSM(dt_*pre.template Get<STA_ROR>())));
+    this->template SetJacPre<OUT_VEL, STA_ATT>(J, pre, -pre.template Get<STA_ATT>().inverse().toRotationMatrix()*SSM(g_*dt_));
+    this->template SetJacPre<OUT_VEL, STA_ROR>(J, pre, -SSM(dt_*pre.template Get<STA_VEL>()));
+    this->template SetJacPre<OUT_VEL, STA_ACB>(J, pre, dt_*Mat3::Identity());
     return 0;
   }
   int JacCur(MatRefX J, const typename Previous::CRef pre, const typename Current::CRef cur){
-    J.block<3,3>(Output::Start(OUT_VEL),cur.Start(STA_VEL)) = Mat3::Identity();
+    this->template SetJacCur<OUT_VEL, STA_VEL>(J, cur, Mat3::Identity());
     return 0;
   }
   double GetWeight(){

--- a/include/tsif/residuals/gyroscope_update.h
+++ b/include/tsif/residuals/gyroscope_update.h
@@ -43,8 +43,8 @@ class GyroscopeUpdate: public GyroscopeUpdateBase<OUT_ROR,STA_ROR,STA_GYB>{
     return 0;
   }
   int JacCur(MatRefX J, const typename Previous::CRef pre, const typename Current::CRef cur){
-    J.block<3,3>(Output::Start(OUT_ROR),cur.Start(STA_ROR)) = Mat3::Identity();
-    J.block<3,3>(Output::Start(OUT_ROR),cur.Start(STA_GYB)) = Mat3::Identity();
+    this->template SetJacCur<OUT_ROR,STA_ROR>(J,cur,Mat3::Identity());
+    this->template SetJacCur<OUT_ROR,STA_GYB>(J,cur,Mat3::Identity());
     return 0;
   }
   double GetWeight(){


### PR DESCRIPTION
Use jacobian setter functions instead of eigen block operations to set the jacs for the accelerometer prediction and gyro update.

This allows the residuals to propperly handle the imu biases as constant parameters with negative indices (which is the case for the accelerometer bias on rezero).